### PR TITLE
Change format to replace

### DIFF
--- a/twitch_chatlog_to_html.py
+++ b/twitch_chatlog_to_html.py
@@ -59,7 +59,8 @@ def messageContainer(username,content,user_color):
 
 def intoTemplate(filename,content):
 	with codecs.open(filename, encoding='utf-8') as f:
-		return f.read().format(content);
+		htmlSite = f.read()
+		return htmlSize.replace("{0}", content)
 
 def findEmote(word,full = True):
 	if isinstance(word,re.Match): 


### PR DESCRIPTION
with python 3.8.3 the format will throw an exception because it sees { in the css. Not the best solution but it works atleast for me.